### PR TITLE
Added seedable rng for decks

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -420,7 +420,7 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
             if (gameReq.board === "random") {
                 const boards = Object.values(BoardName);
-                gameReq.board = boards[Math.floor(Math.random() * boards.length)];
+                gameReq.board = boards[Math.floor(parseInt(gameId, 16) / Math.pow(16, 12) * boards.length)];
             }
 
             const gameOptions = {
@@ -436,8 +436,6 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
                 coloniesExtension: gameReq.colonies,
                 preludeExtension: gameReq.prelude,
                 turmoilExtension: gameReq.turmoil,
-                aresExtension: gameReq.aresExtension,
-                aresHazards: true, // Not a runtime option.
                 promoCardsOption: gameReq.promoCardsOption,
                 communityCardsOption: gameReq.communityCardsOption,
                 solarPhaseOption: gameReq.solarPhaseOption,


### PR DESCRIPTION
The game.id (which is random) is used to seed random number generators for shuffling the corporate, prelude and project decks.
Also, the game.id itself is used to select one of the three main boards when that is random.